### PR TITLE
removing the requirement for a Content-Type header on the GET method

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -6,6 +6,9 @@
     <file url="file://$PROJECT_DIR$/chat-service/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/common/auth-client/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/common/exception/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/config/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/gateway/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/registry/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,18 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="b52ce3e4-3047-4dc8-a854-88fa60a134df" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/encodings.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/encodings.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/account-service/src/test/resources/application.yml" beforeDir="false" afterPath="$PROJECT_DIR$/account-service/src/test/resources/application.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/account-service/src/main/java/com/chatwave/accountservice/controller/AccountController.java" beforeDir="false" afterPath="$PROJECT_DIR$/account-service/src/main/java/com/chatwave/accountservice/controller/AccountController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/account-service/src/test/java/com/chatwave/accountservice/integration/controller/AccountControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/account-service/src/test/java/com/chatwave/accountservice/integration/controller/AccountControllerTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/auth-service/src/main/java/com/chatwave/authservice/controller/SessionController.java" beforeDir="false" afterPath="$PROJECT_DIR$/auth-service/src/main/java/com/chatwave/authservice/controller/SessionController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/auth-service/src/test/java/com/chatwave/authservice/integration/controller/SessionControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/auth-service/src/test/java/com/chatwave/authservice/integration/controller/SessionControllerTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/auth-service/src/test/java/com/chatwave/authservice/integration/controller/UserControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/auth-service/src/test/java/com/chatwave/authservice/integration/controller/UserControllerTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/auth-service/src/test/java/com/chatwave/authservice/integration/securityConfig/UserAuthFilterTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/auth-service/src/test/java/com/chatwave/authservice/integration/securityConfig/UserAuthFilterTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/chat-service/src/main/java/com/chatwave/chatservice/controller/ChatController.java" beforeDir="false" afterPath="$PROJECT_DIR$/chat-service/src/main/java/com/chatwave/chatservice/controller/ChatController.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/config/src/main/resources/shared/application.yml" beforeDir="false" afterPath="$PROJECT_DIR$/config/src/main/resources/shared/application.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/config/src/main/resources/shared/gateway.yml" beforeDir="false" afterPath="$PROJECT_DIR$/config/src/main/resources/shared/gateway.yml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -62,7 +71,7 @@
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "WebServerToolWindowFactoryState": "false",
     "deletionFromPopupRequiresConfirmation": "false",
-    "git-widget-placeholder": "feature/new-integration-tests",
+    "git-widget-placeholder": "fix/consumer-value-in-controllers-annotation",
     "jdk.selected.JAVA_MODULE": "20",
     "last_opened_file_path": "/Users/patryklikus/Programowanie/ChatWave/chat-service/src/test/java/com/chatwave/chatservice",
     "node.js.detected.package.eslint": "true",
@@ -106,6 +115,9 @@
       <recent name="com.chatwave.accountservice.utils" />
       <recent name="com.chatwave.accountservice.client.dto" />
     </key>
+    <key name="ImportMappingsDialog.RecentPackages">
+      <recent name="" />
+    </key>
   </component>
   <component name="RunDashboard">
     <option name="configurationTypes">
@@ -114,17 +126,17 @@
       </set>
     </option>
   </component>
-  <component name="RunManager" selected="JUnit.account service">
-    <configuration name="ChatControllerTest" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
-      <module name="chat-service" />
+  <component name="RunManager" selected="JUnit.chat-service">
+    <configuration name="ClientAuthTest" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+      <module name="auth-service" />
       <extension name="coverage">
         <pattern>
-          <option name="PATTERN" value="com.chatwave.chatservice.integration.controller.*" />
+          <option name="PATTERN" value="com.chatwave.authservice.integration.securityConfig.*" />
           <option name="ENABLED" value="true" />
         </pattern>
       </extension>
-      <option name="PACKAGE_NAME" value="com.chatwave.chatservice.integration.controller" />
-      <option name="MAIN_CLASS_NAME" value="com.chatwave.chatservice.integration.controller.ChatControllerTest" />
+      <option name="PACKAGE_NAME" value="com.chatwave.authservice.integration.securityConfig" />
+      <option name="MAIN_CLASS_NAME" value="com.chatwave.authservice.integration.securityConfig.ClientAuthTest" />
       <option name="TEST_OBJECT" value="class" />
       <method v="2">
         <option name="Make" enabled="true" />
@@ -252,25 +264,36 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
+    <configuration name="development" type="docker-deploy" factoryName="docker-compose.yml" temporary="true" server-name="Docker">
+      <deployment type="docker-compose.yml">
+        <settings>
+          <option name="envFilePath" value="" />
+          <option name="sourceFilePath" value="docker-compose.dev.yml" />
+        </settings>
+      </deployment>
+      <method v="2" />
+    </configuration>
     <list>
-      <item itemvalue="JUnit.ChatControllerTest" />
-      <item itemvalue="JUnit.chat-service" />
+      <item itemvalue="Docker.development" />
+      <item itemvalue="JUnit.ClientAuthTest" />
       <item itemvalue="JUnit.account service" />
       <item itemvalue="JUnit.auth service" />
-      <item itemvalue="Spring Boot.TestApplication" />
-      <item itemvalue="Spring Boot.ChatServiceApplication" />
-      <item itemvalue="Spring Boot.AuthServiceApplication" />
+      <item itemvalue="JUnit.chat-service" />
       <item itemvalue="Spring Boot.AccountServiceApplication" />
+      <item itemvalue="Spring Boot.AuthServiceApplication" />
+      <item itemvalue="Spring Boot.ChatServiceApplication" />
       <item itemvalue="Spring Boot.ConfigApplication" />
       <item itemvalue="Spring Boot.GatewayApplication" />
       <item itemvalue="Spring Boot.RegistryApplication" />
+      <item itemvalue="Spring Boot.TestApplication" />
     </list>
     <recent_temporary>
       <list>
-        <item itemvalue="JUnit.account service" />
         <item itemvalue="JUnit.chat-service" />
-        <item itemvalue="JUnit.ChatControllerTest" />
+        <item itemvalue="JUnit.account service" />
         <item itemvalue="JUnit.auth service" />
+        <item itemvalue="Docker.development" />
+        <item itemvalue="JUnit.ClientAuthTest" />
       </list>
     </recent_temporary>
   </component>
@@ -305,6 +328,12 @@
       <workItem from="1694266361346" duration="21813000" />
       <workItem from="1694338338745" duration="340000" />
       <workItem from="1694347282140" duration="305000" />
+      <workItem from="1694381278056" duration="3688000" />
+      <workItem from="1694425380554" duration="1942000" />
+      <workItem from="1694464231951" duration="469000" />
+      <workItem from="1694544919621" duration="672000" />
+      <workItem from="1694545603539" duration="35000" />
+      <workItem from="1694545649125" duration="1683000" />
     </task>
     <servers />
   </component>

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Still in active development.
 **Deploying** `Docker` `Docker Compose`
 
 ## Functional services
-Chat wave is decomposed into three core microservices. All of them have own database and have a different business role.
+Chat wave is decomposed into three core microservices. All of them have own database and have a different business role. 
 
 ![diagram showing the structure of the services](.doc/functional-services.png)
-
+Services only accept and produce json.
 Each endpoint used by users are protected by csrf protection. The following profile disables this protection (however it is not recommended):
 ```yaml
 spring.profiles.active: csrf_disable

--- a/account-service/src/main/java/com/chatwave/accountservice/controller/AccountController.java
+++ b/account-service/src/main/java/com/chatwave/accountservice/controller/AccountController.java
@@ -16,20 +16,20 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
-@RequestMapping(value = "/accounts", consumes = APPLICATION_JSON, produces = APPLICATION_JSON)
+@RequestMapping(value = "/accounts", produces = APPLICATION_JSON)
 @RequiredArgsConstructor
 public class AccountController {
     private final AccountService service;
     private final AccountMapper mapper;
 
-    @PostMapping
+    @PostMapping(consumes = APPLICATION_JSON)
     @ResponseStatus(CREATED)
     public TokenSet createAccount(@Valid @RequestBody CreateAccountRequest body) {
         var account = mapper.toAccount(body);
         return service.createAccount(account, body.loginName(), body.password());
     }
 
-    @PostMapping("/authenticate")
+    @PostMapping(value = "/authenticate", consumes = APPLICATION_JSON)
     public TokenSet authenticateAccount(@RequestBody AuthenticationRequest body) {
         return service.authenticateAccount(body);
     }
@@ -46,7 +46,7 @@ public class AccountController {
         return mapper.toAccountShowcase(account);
     }
 
-    @PatchMapping("/{accountId}")
+    @PatchMapping(value = "/{accountId}", consumes = APPLICATION_JSON)
     @PreAuthorize("#accountId == authentication.principal")
     public void patchAccount(@PathVariable Integer accountId, @Valid @RequestBody PatchAccountRequest body) {
         service.patchAccount(accountId, body);

--- a/account-service/src/test/java/com/chatwave/accountservice/integration/controller/AccountControllerTest.java
+++ b/account-service/src/test/java/com/chatwave/accountservice/integration/controller/AccountControllerTest.java
@@ -136,7 +136,6 @@ public class AccountControllerTest {
 
             var result = webTestClient.get()
                     .uri("/accounts/{id}/showcase", accountId)
-                    .header("Content-type", APPLICATION_JSON)
                     .header("User-Authorization", BEARER_TOKEN)
                     .exchange()
                     .expectStatus().isOk()

--- a/auth-service/src/main/java/com/chatwave/authservice/controller/SessionController.java
+++ b/auth-service/src/main/java/com/chatwave/authservice/controller/SessionController.java
@@ -20,7 +20,7 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/sessions", consumes = APPLICATION_JSON, produces = APPLICATION_JSON)
+@RequestMapping(value = "/sessions", produces = APPLICATION_JSON)
 public class SessionController {
     private final SessionService service;
     private final SessionMapper mapper;
@@ -38,14 +38,14 @@ public class SessionController {
                 .toList();
     }
 
-    @PostMapping
+    @PostMapping(consumes = APPLICATION_JSON)
     @PreAuthorize("hasAuthority('SCOPE_server')")
     public TokenSetResponse createSessions(@Valid @RequestBody CreateSessionRequest body) {
         var session = service.createSession(body.userId());
         return mapper.toTokenSetResponse(session);
     }
 
-    @PostMapping("/refresh")
+    @PostMapping(value = "/refresh", consumes = APPLICATION_JSON)
     public TokenSetResponse refreshTokens(@Valid @RequestBody RefreshSessionRequest body) {
         var session = service.refreshSession(body.refreshToken());
         return mapper.toTokenSetResponse(session);

--- a/auth-service/src/test/java/com/chatwave/authservice/integration/controller/SessionControllerTest.java
+++ b/auth-service/src/test/java/com/chatwave/authservice/integration/controller/SessionControllerTest.java
@@ -80,7 +80,6 @@ public class SessionControllerTest {
         public void t200() {
             var sessions = webTestClient.get()
                     .uri("/sessions")
-                    .header("Content-type", APPLICATION_JSON)
                     .header("User-Authorization", oauthUserService.getAuthHeader())
                     .exchange()
                     .expectStatus().isOk()
@@ -112,7 +111,6 @@ public class SessionControllerTest {
         public void t200() {
             var userAuthentication = webTestClient.get()
                     .uri("/sessions/authentication")
-                    .header("Content-type", APPLICATION_JSON)
                     .header("Authorization", oauthClientService.getAuthHeader())
                     .header("User-Authorization", oauthUserService.getAuthHeader())
                     .exchange()
@@ -141,7 +139,6 @@ public class SessionControllerTest {
         public void t200() {
             var tokenSet = webTestClient.post()
                     .uri("/sessions/refresh")
-                    .header("Content-type", APPLICATION_JSON)
                     .bodyValue(new RefreshSessionRequest(session1.getRefreshToken()))
                     .exchange()
                     .expectStatus().isOk()
@@ -172,7 +169,6 @@ public class SessionControllerTest {
         public void t200() {
             webTestClient.delete()
                     .uri("/sessions")
-                    .header("Content-type", APPLICATION_JSON)
                     .header("User-Authorization", oauthUserService.getAuthHeader())
                     .exchange()
                     .expectStatus().isOk();
@@ -197,7 +193,6 @@ public class SessionControllerTest {
         public void t200() {
             webTestClient.delete()
                     .uri("/sessions/{id}", session1.getId())
-                    .header("Content-type", APPLICATION_JSON)
                     .header("User-Authorization", oauthUserService.getAuthHeader())
                     .exchange()
                     .expectStatus().isOk();
@@ -213,7 +208,6 @@ public class SessionControllerTest {
         public void t404() {
             webTestClient.delete()
                     .uri("/sessions/{id}", session1.getId() + 1)
-                    .header("Content-type", APPLICATION_JSON)
                     .header("User-Authorization", oauthUserService.getAuthHeader())
                     .exchange()
                     .expectStatus().isNotFound();

--- a/auth-service/src/test/java/com/chatwave/authservice/integration/controller/UserControllerTest.java
+++ b/auth-service/src/test/java/com/chatwave/authservice/integration/controller/UserControllerTest.java
@@ -177,7 +177,6 @@ public class UserControllerTest {
         public void t200() {
             webTestClient.put()
                     .uri(ENDPOINT, userId)
-                    .header("Content-type", APPLICATION_JSON)
                     .header("Authorization", oauthClientService.getAuthHeader())
                     .bodyValue(new UpdatePasswordRequest(PASSWORD_2))
                     .exchange()
@@ -197,7 +196,6 @@ public class UserControllerTest {
         public void t400() {
             webTestClient.put()
                     .uri(ENDPOINT, userId)
-                    .header("Content-type", APPLICATION_JSON)
                     .header("Authorization", oauthClientService.getAuthHeader())
                     .bodyValue(new UpdatePasswordRequest(INVALID_PASSWORD))
                     .exchange()

--- a/auth-service/src/test/java/com/chatwave/authservice/integration/securityConfig/UserAuthFilterTest.java
+++ b/auth-service/src/test/java/com/chatwave/authservice/integration/securityConfig/UserAuthFilterTest.java
@@ -51,7 +51,6 @@ public class UserAuthFilterTest {
     public void t1() {
         webTestClient.get()
                 .uri(ENDPOINT)
-                .header("Content-type", APPLICATION_JSON)
                 .header("User-Authorization", "Bearer " + ACCESS_TOKEN)
                 .exchange()
                 .expectStatus().isOk();

--- a/chat-service/src/main/java/com/chatwave/chatservice/controller/ChatController.java
+++ b/chat-service/src/main/java/com/chatwave/chatservice/controller/ChatController.java
@@ -15,8 +15,10 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
 @RestController
-@RequestMapping("/chat")
+@RequestMapping(value = "/chat", produces = APPLICATION_JSON)
 @RequiredArgsConstructor
 @Slf4j
 public class ChatController {
@@ -37,7 +39,7 @@ public class ChatController {
                 .toList();
     }
 
-    @PostMapping("/{receiverId}")
+    @PostMapping(value = "/{receiverId}", consumes = APPLICATION_JSON)
     public void sendMessage(@Valid @RequestBody SendMessageRequest sendMessageRequest, @AuthenticationPrincipal Integer authorId, @PathVariable Integer receiverId) {
         var message = mapper.toMessage(sendMessageRequest, authorId, receiverId);
         service.sendMessage(message);

--- a/config/src/main/resources/shared/gateway.yml
+++ b/config/src/main/resources/shared/gateway.yml
@@ -8,7 +8,6 @@ spring:
         - id: auth-route
           uri: lb://auth-service
           predicates:
-            - Path=/users/**
             - Path=/sessions/**
 
         - id: account-route


### PR DESCRIPTION
I removed the requirement for a `Content-Type` header on the `GET` method.
Add information about requirement of `Accept`and `Content-Type` header in readme.